### PR TITLE
fix: pim resource assignments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -580,23 +580,23 @@ resource "azurerm_pim_eligible_role_assignment" "role" {
   role_definition_id = (
     each.value.existing_role_definition == true ?
     (
-      # For existing role definitions, check if scope is management group
+      # For existing role definitions
       startswith(each.value.scope, "/providers/Microsoft.Management/managementGroups/") ?
       data.azurerm_role_definition.custom[each.value.role].role_definition_id :
-      "${each.value.scope}${data.azurerm_role_definition.custom[each.value.role].role_definition_id}"
+      "${regex("^/subscriptions/[^/]+", each.value.scope)}${data.azurerm_role_definition.custom[each.value.role].role_definition_id}"
     ) :
     contains(try(keys(var.role_definitions), []), each.value.role) ?
     (
-      # For custom role definitions, check if scope is management group
+      # For custom role definitions
       startswith(each.value.scope, "/providers/Microsoft.Management/managementGroups/") ?
       azurerm_role_definition.custom[each.value.role].role_definition_id :
-      "${each.value.scope}${azurerm_role_definition.custom[each.value.role].role_definition_id}"
+      "${regex("^/subscriptions/[^/]+", each.value.scope)}${azurerm_role_definition.custom[each.value.role].role_definition_id}"
     ) :
     (
-      # For builtin role definitions, check if scope is management group
+      # For builtin role definitions
       startswith(each.value.scope, "/providers/Microsoft.Management/managementGroups/") ?
       data.azurerm_role_definition.builtin[each.key].role_definition_id :
-      "${each.value.scope}${data.azurerm_role_definition.builtin[each.key].role_definition_id}"
+      "${regex("^/subscriptions/[^/]+", each.value.scope)}${data.azurerm_role_definition.builtin[each.key].role_definition_id}"
     )
   )
   principal_id = element(compact([

--- a/main.tf
+++ b/main.tf
@@ -577,7 +577,28 @@ resource "azurerm_pim_eligible_role_assignment" "role" {
   }
 
   scope              = each.value.scope
-  role_definition_id = each.value.existing_role_definition == true ? data.azurerm_role_definition.custom[each.value.role].role_definition_id : contains(try(keys(var.role_definitions), []), each.value.role) ? azurerm_role_definition.custom[each.value.role].role_definition_id : data.azurerm_role_definition.builtin[each.key].role_definition_id
+  role_definition_id = (
+    each.value.existing_role_definition == true ?
+    (
+      # For existing role definitions, check if scope is management group
+      startswith(each.value.scope, "/providers/Microsoft.Management/managementGroups/") ?
+      data.azurerm_role_definition.custom[each.value.role].role_definition_id :
+      "${each.value.scope}${data.azurerm_role_definition.custom[each.value.role].role_definition_id}"
+    ) :
+    contains(try(keys(var.role_definitions), []), each.value.role) ?
+    (
+      # For custom role definitions, check if scope is management group
+      startswith(each.value.scope, "/providers/Microsoft.Management/managementGroups/") ?
+      azurerm_role_definition.custom[each.value.role].role_definition_id :
+      "${each.value.scope}${azurerm_role_definition.custom[each.value.role].role_definition_id}"
+    ) :
+    (
+      # For builtin role definitions, check if scope is management group
+      startswith(each.value.scope, "/providers/Microsoft.Management/managementGroups/") ?
+      data.azurerm_role_definition.builtin[each.key].role_definition_id :
+      "${each.value.scope}${data.azurerm_role_definition.builtin[each.key].role_definition_id}"
+    )
+  )
   principal_id = element(compact([
     try(each.value.pim_eligible.principal_id, null),
     each.value.type == "Group" && each.value.display_name != null ? data.azuread_group.group[each.key].object_id : null,

--- a/main.tf
+++ b/main.tf
@@ -576,7 +576,7 @@ resource "azurerm_pim_eligible_role_assignment" "role" {
     if assignment.pim_eligible != null
   }
 
-  scope              = each.value.scope
+  scope = each.value.scope
   role_definition_id = (
     each.value.existing_role_definition == true ?
     (


### PR DESCRIPTION
## Description

When an pim_eligible role assignment on a subscription or resource group is set, the role_definition_id needs to include the /subcriptions/xxx-xxxx../ prefix. To make sure that it works as well for role assignments on management groups, we need to include an check that validates the scope and adjust the role_definition_id accordingly. 

Without it, the API call to check the existence fails with a ResourceNotFound error.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

When an pim_eligible role assignment on a subscription or resource group is set, the role_definition_id needs to include the /subcriptions/xxx-xxxx../ prefix. To make sure that it works as well for role assignments on management groups, we need to include an check that validates the scope and adjust the role_definition_id accordingly. 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
